### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ name = "ccash-rs"
 version = "2.0.0-beta.1"
 authors = ["STBoyden <sam@stboyden.com>"]
 description = "The Rust bindings for the CCash ledger API (CCash available here: https://github.com/EntireTwix/CCash)."
-homepage = "http://github.com/STBoyden/ccash-rs"
+homepage = "https://github.com/STBoyden/ccash-rs"
 documentation = "https://docs.rs/ccash-rs"
 keywords = ["minecraft", "webdev", "ccash", "api"]
 license = "MIT"
-repository = "http://github.com/STBoyden/ccash-rs"
+repository = "https://github.com/STBoyden/ccash-rs"
 
 [dependencies]
 chrono = "0.4.23"


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97